### PR TITLE
fix: prevent semantic-release success step from failing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -342,7 +341,6 @@
       "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
@@ -376,7 +374,6 @@
       "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^3.0.0",
@@ -398,7 +395,6 @@
       "integrity": "sha512-qyqLS+aSGH1SfXIooBKjs7mvrv0deg8v+jemegfJg1kq6ji+GJV8CO08VJDEsvjp3O8XJmTTIAjjZbMzagzsdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/core": "^7.0.0",
         "@octokit/plugin-paginate-rest": "^14.0.0",
@@ -627,7 +623,6 @@
       "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
@@ -1091,7 +1086,6 @@
       "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
@@ -2234,7 +2228,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2415,9 +2408,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.7.0.tgz",
-      "integrity": "sha512-wiCZpv/41bIobCoJ31NStIWKfAxxYyD1iYnWCtiyns8s5v3+l8y0HCP/sScuH6B5+GhIfda4HQKiqeGZwJWhFw==",
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.10.1.tgz",
+      "integrity": "sha512-woavuY2OgDFQ1K/tB9QHsUuW989nKfvsKTN/h5qGyS+3+BhvXN/DA2TNzx569JaFfTqrET5bEQNHwVhFk+U1gg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2435,7 +2428,6 @@
         "cacache",
         "chalk",
         "ci-info",
-        "cli-columns",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -2497,47 +2489,46 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.9",
-        "@npmcli/config": "^10.4.5",
+        "@npmcli/arborist": "^9.3.1",
+        "@npmcli/config": "^10.7.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
-        "@npmcli/package-json": "^7.0.4",
+        "@npmcli/package-json": "^7.0.5",
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.3",
-        "@sigstore/tuf": "^4.0.0",
+        "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
         "cacache": "^20.0.3",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
-        "cli-columns": "^4.0.0",
+        "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^13.0.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
-        "init-package-json": "^8.2.4",
-        "is-cidr": "^6.0.1",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.12",
-        "libnpmexec": "^10.1.11",
-        "libnpmfund": "^7.0.12",
+        "libnpmdiff": "^8.1.2",
+        "libnpmexec": "^10.2.2",
+        "libnpmfund": "^7.0.16",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.12",
+        "libnpmpack": "^9.1.2",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
         "make-fetch-happen": "^15.0.3",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.1",
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.1.0",
+        "node-gyp": "^12.2.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -2547,21 +2538,21 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.0.4",
+        "pacote": "^21.3.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^13.0.0",
+        "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.2",
+        "tar": "^7.5.9",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^7.0.0",
-        "which": "^6.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -2601,27 +2592,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "dev": true,
@@ -2657,7 +2627,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.9",
+      "version": "9.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2675,7 +2645,7 @@
         "@npmcli/run-script": "^10.0.0",
         "bin-links": "^6.0.0",
         "cacache": "^20.0.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
         "lru-cache": "^11.2.1",
@@ -2704,7 +2674,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.4.5",
+      "version": "10.7.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2819,7 +2789,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "7.0.4",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2830,7 +2800,7 @@
         "json-parse-even-better-errors": "^5.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -2899,7 +2869,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -2917,52 +2887,43 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.0.1",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.2",
-        "proc-log": "^5.0.0",
+        "make-fetch-happen": "^15.0.3",
+        "proc-log": "^6.1.0",
         "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.0.0"
+        "tuf-js": "^4.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -2979,31 +2940,16 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
+        "minimatch": "^10.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -3024,15 +2970,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
       "dev": true,
@@ -3046,10 +2983,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.0",
@@ -3080,12 +3020,15 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
@@ -3132,7 +3075,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -3147,28 +3090,12 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.1",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "5.0.0"
-      },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
@@ -3181,10 +3108,13 @@
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
@@ -3216,19 +3146,13 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
@@ -3283,17 +3207,17 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "13.0.0",
+      "version": "13.0.6",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3393,7 +3317,7 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "8.2.4",
+      "version": "8.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3403,7 +3327,6 @@
         "promzard": "^3.0.1",
         "read": "^5.0.1",
         "semver": "^7.7.2",
-        "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
@@ -3411,7 +3334,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3419,46 +3342,25 @@
         "node": ">= 12"
       }
     },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.1",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "5.0.1"
+        "cidr-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/isexe": {
-      "version": "3.1.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
@@ -3514,12 +3416,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.12",
+      "version": "8.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3533,12 +3435,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.11",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -3556,12 +3458,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.12",
+      "version": "7.0.16",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9"
+        "@npmcli/arborist": "^9.3.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3581,12 +3483,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.12",
+      "version": "9.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -3656,10 +3558,10 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.2",
+      "version": "11.2.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -3687,25 +3589,25 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.1.1",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3723,13 +3625,13 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
@@ -3763,6 +3665,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "dev": true,
@@ -3787,25 +3695,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "ISC"
     },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
@@ -3848,7 +3750,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.1.0",
+      "version": "12.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3860,7 +3762,7 @@
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.5.2",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
         "which": "^6.0.0"
       },
@@ -4025,7 +3927,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.4",
+      "version": "21.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4070,7 +3972,7 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4079,14 +3981,14 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4205,7 +4107,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4229,17 +4131,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "@sigstore/verify": "^3.0.0"
+        "@sigstore/sign": "^4.1.0",
+        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/verify": "^3.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4283,26 +4185,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "dev": true,
@@ -4326,7 +4208,7 @@
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4335,32 +4217,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
@@ -4376,7 +4232,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.2",
+      "version": "7.5.9",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4387,15 +4243,6 @@
         "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -4450,7 +4297,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4468,14 +4314,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "4.0.0",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^15.0.0"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4511,28 +4357,8 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4550,12 +4376,12 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "6.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
@@ -4578,10 +4404,13 @@
       }
     },
     "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5040,7 +4869,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -5790,7 +5618,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "semantic-release": "^25.0.2"
   },
   "overrides": {
-    "tar": "^7.5.3",
+    "tar": ">=7.5.8",
+    "npm": ">=11.10.1",
     "cross-spawn": "^7.0.6",
     "brace-expansion": "^2.0.2"
   }

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,6 +1,17 @@
-module.exports = require("@nicxe/semantic-release-config")({
+const config = require("@nicxe/semantic-release-config")({
   componentDir: "custom_components/met_rain_risk",
   manifestPath: "custom_components/met_rain_risk/manifest.json",
   projectName: "MET Rain Risk",
   repoSlug: "Nicxe/met_rain_risk"
-});
+}
+);
+
+const githubPlugin = config.plugins.find(
+  (plugin) => Array.isArray(plugin) && plugin[0] === "@semantic-release/github"
+);
+
+if (githubPlugin?.[1]) {
+  githubPlugin[1].successCommentCondition = false;
+}
+
+module.exports = config;


### PR DESCRIPTION
This updates release configuration to skip GitHub success-comment processing that can fail on stale pull request associations. Release publishing remains unchanged while avoiding 404 failures in the success step.