### PR TITLE
chore: update overrides to fix undici and tar security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,19 +46,6 @@
         "undici": "^5.28.5"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
@@ -100,16 +87,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@nicxe/semantic-release-config": {
@@ -5786,9 +5763,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "semantic-release": "^25.0.3"
   },
   "overrides": {
-    "tar": "^7.5.3",
+    "tar": "^7.5.11",
     "cross-spawn": "^7.0.6",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "undici": ">=7.24.0"
   }
 }


### PR DESCRIPTION
Updates the npm overrides to address known security vulnerabilities in transitive dependencies.

- `tar` bumped from `^7.5.3` to `^7.5.11` to resolve a high-severity vulnerability.
- `undici` added at `>=7.24.0` to address a high-severity vulnerability in that transitive dependency.