### PR TITLE
fix(security): update ip-address and undici lock entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3277,7 +3277,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4232,7 +4232,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary
- update the bundled `ip-address` lock entry from 10.2.0 to 10.3.1
- update the bundled `undici` lock entry from 6.27.0 to 6.28.0
- address Dependabot alerts #53, #54, #61, #62, #63, and #64

## Validation
- `python3 -m unittest discover -s tests -v` (1 test passed)
- `npm audit` no longer reports `ip-address` or `undici`; 5 unrelated vulnerabilities remain (4 moderate, 1 high)
- `git diff --check`

## Notes
- `npm ci --ignore-scripts` could not complete locally because the available GitHub token lacks package-read permission for `@nicxe/semantic-release-config`.
- No application code is changed.